### PR TITLE
feat: make `yarn install` also fetch missing plugins

### DIFF
--- a/.yarn/versions/13f288ec.yml
+++ b/.yarn/versions/13f288ec.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
@@ -1,7 +1,7 @@
-import {xfs}           from '@yarnpkg/fslib';
-import {stringifySyml} from '@yarnpkg/parsers';
+import {PortablePath, xfs} from '@yarnpkg/fslib';
+import {stringifySyml}     from '@yarnpkg/parsers';
 
-const PLUGIN = (name, {async = false, printOnBoot = false} = {}) => `
+const PLUGIN = (name: string, {async = false, printOnBoot = false} = {}) => `
 const factory = ${async ? `async` : ``} r => {
   const {Command} = r('clipanion');
 
@@ -31,9 +31,9 @@ describe(`Features`, () => {
   describe(`Plugins`, () => {
     test(`it should properly load a plugin via the local rc file`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`a`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`a`, {printOnBoot: true}));
 
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
         plugins: [`./plugin-a.js`],
       }));
 
@@ -46,9 +46,9 @@ describe(`Features`, () => {
 
     test(`it should accept asynchronous plugins`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`a`, {async: true}));
+      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`a`, {async: true}));
 
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
         plugins: [`./plugin-a.js`],
       }));
 
@@ -61,9 +61,9 @@ describe(`Features`, () => {
 
     test(`it should properly load a plugin via the local rc file`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`A`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`A`, {printOnBoot: true}));
 
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
         plugins: [`./plugin-a.js`],
       }));
 
@@ -76,10 +76,10 @@ describe(`Features`, () => {
 
     test(`it should properly load multiple plugins via the local rc file, in the right order`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`A`, {printOnBoot: true}));
-      await xfs.writeFilePromise(`${path}/plugin-b.js`, PLUGIN(`B`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`A`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-b.js` as PortablePath, PLUGIN(`B`, {printOnBoot: true}));
 
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
         plugins: [`./plugin-a.js`, `./plugin-b.js`],
       }));
 

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -66,10 +66,17 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     if (!ignoreNode && !semverUtils.satisfiesWithPrereleases(version, range))
       throw new UsageError(`This tool requires a Node version compatible with ${range} (got ${version}). Upgrade Node, or set \`YARN_IGNORE_NODE=1\` in your environment.`);
 
+    // We register those third-party plugin commands in this file according to `.yarnrc.yml`,
+    // but in some cases the user's `.yarn/plugins` and `.yarnrc.yml` do not match up,
+    // we would like users to use `yarn install` to try to install missing plugins.
+    // detail: https://github.com/yarnpkg/berry/issues/4464
+    const isInstalling = process.argv.slice(2).length === 0 || process.argv.slice(2).includes(`install`);
+
     // Since we only care about a few very specific settings (yarn-path and ignore-path) we tolerate extra configuration key.
     // If we didn't, we wouldn't even be able to run `yarn config` (which is recommended in the invalid config error message)
     const configuration = await Configuration.find(npath.toPortablePath(process.cwd()), pluginConfiguration, {
       usePath: true,
+      useThirdPartyPlugin: !isInstalling,
       strict: false,
     });
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -883,6 +883,7 @@ function getEnvironmentSettings() {
     environmentSettings[key] = value;
   }
 
+  delete environmentSettings.rcFilename;
   return environmentSettings;
 }
 
@@ -990,7 +991,6 @@ export class Configuration {
 
   static async find(startingCwd: PortablePath, pluginConfiguration: PluginConfiguration | null, {lookup = ProjectLookup.LOCKFILE, strict = true, usePath = false, useRc = true}: FindProjectOptions = {}) {
     const environmentSettings = getEnvironmentSettings();
-    delete environmentSettings.rcFilename;
 
     const rcFiles = await Configuration.findRcFiles(startingCwd);
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1075,7 +1075,15 @@ export class Configuration {
       for (const request of pluginConfiguration.plugins.keys())
         plugins.set(request, getDefault(pluginConfiguration.modules.get(request)));
       if (useThirdPartyPlugin) {
-        await configuration.useThirdPartyPlugin(pluginConfiguration, {useRc});
+        try {
+          await configuration.useThirdPartyPlugin(pluginConfiguration, {useRc});
+        } catch (err) {
+          if (err.code === `MODULE_NOT_FOUND`) {
+            throw new UsageError(`There are some plugins missing, please run \`yarn install\` to reinstall it`);
+          } else {
+            throw err;
+          }
+        }
       }
     }
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -896,6 +896,10 @@ function getRcFilename() {
   return DEFAULT_RC_FILENAME as Filename;
 }
 
+function getDefault(object: any) {
+  return `default` in object ? object.default : object;
+}
+
 export enum ProjectLookup {
   LOCKFILE,
   MANIFEST,
@@ -1065,10 +1069,6 @@ export class Configuration {
     const plugins = new Map<string, Plugin>([
       [`@@core`, CorePlugin],
     ]);
-
-    const getDefault = (object: any) => {
-      return `default` in object ? object.default : object;
-    };
 
     if (pluginConfiguration !== null) {
       for (const request of pluginConfiguration.plugins.keys())

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -94,6 +94,9 @@ export enum MessageName {
   NETWORK_DISABLED = 80,
   NETWORK_UNSAFE_HTTP = 81,
   RESOLUTION_FAILED = 82,
+  PLUGIN_NOT_FOUND = 83,
+  REFETCH_PLUGIN_FAILED = 84,
+  GITIGNORE_INFO = 85,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When the user loses the `.yarn/plugins` directory, all yarn commands will fail. 

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

1. allow `Configuration` to loading third-party plugins later 9f38b014824fbb72998f370a9682112aebaccbe2 ba3e8b78dfc79939e7a9c9cc34975538c2344fc6 9ccf393b54ee79f89d3712f450d87f66cbf9f55f

2. if the error is due to a missing plugin, guide the user to run the `yarn install` command ddd9fb74fdddb1c2dcacccde5e6b90547da92079

3. make the `yarnpkg-cli` not load third-party plugin commands when the `yarn install` runs 43c1cd834091ee915e54e7c002f8f88d2985cc96

4. allow `yarn install` command to automatically fetch missing third-party plugins 81a9fad625dbc866dc57167122d76c828e147043

5. test 7dbfab32fe7c77893234c6168c9b1e583c0e7035 399ef48e418125379db2fa29a41a466cb0654dd5
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
